### PR TITLE
GPU memory efficient L2 norm

### DIFF
--- a/source/dot_product.cu
+++ b/source/dot_product.cu
@@ -88,7 +88,7 @@ int dotProduct_dVectors(dVector a, dVector b, double *result) {
 	dotProduct_dVector_kernel<<<gridSize, BLOCKSIZE >>>(device_a, device_b, device_partial, a.len);
 	cudaStatus = cudaGetLastError();
 	if (cudaStatus != cudaSuccess) {
-		fprintf(stderr, "add_dVector_kernel launch failed: %s\n", cudaGetErrorString(cudaStatus));
+		fprintf(stderr, "dotProduct_dVector_kernel launch failed: %s\n", cudaGetErrorString(cudaStatus));
 		goto Error;
 	}
 

--- a/source/l2_norm.cu
+++ b/source/l2_norm.cu
@@ -1,31 +1,128 @@
 #include "l2_norm.cuh"
 
-int l2_norm_dVectors(dVector a, dVector b, double *result) {
-	int error = dotProduct_dVectors(a, b, result);
-	if (error != 0)
-		return error;
-	*result = sqrt(*result);
-	return 0;
+#define BLOCKSIZE 1024
+
+__global__ void l2_norm_dVector_kernel(double *a, double *partial_sum, int n) {
+	__shared__ double partial_sums[BLOCKSIZE];
+
+	double local_sum = 0;
+
+	int id = blockIdx.x*blockDim.x + threadIdx.x;
+	int partial_index = threadIdx.x;
+
+	while (id < n) {
+		local_sum += (a[id] * a[id]);
+		id += (blockDim.x * gridDim.x); // this thread may have to handle multiple sums
+	}
+
+	partial_sums[partial_index] = local_sum;
+
+	__syncthreads();
+
+	int sum_level = blockDim.x >> 1; // divide by 2
+
+	while (sum_level != 0) {
+		if (partial_index < sum_level) {
+			partial_sums[partial_index] += partial_sums[partial_index + sum_level];
+		}
+
+		__syncthreads();
+
+		sum_level >>= 1; // divide by 2
+	}
+
+	if (partial_index == 0) {
+		// if we are the thread processing index 0 of partial_sums for our block
+		partial_sum[blockIdx.x] = partial_sums[0];
+	}
+	// at this point there is still some partial somes left to compute
+	// inefficient to do so on GPU. Let CPU do this
+}
+
+int l2_norm_dVector(dVector a, double *result) {
+	double *device_a, *host_partial, *device_partial;
+	int sizeInBytes = a.len * sizeof(double);
+	int err = 0;
+
+	cudaError_t cudaStatus;
+
+	int gridSize = (int)ceil((float)a.len / BLOCKSIZE);
+
+	host_partial = (double *)calloc(gridSize, sizeof(double));
+
+	cudaStatus = cudaMalloc(&device_a, sizeInBytes);
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "A: cudaMalloc failed!\n");
+		goto Error;
+	}
+
+	cudaStatus = cudaMalloc(&device_partial, gridSize * sizeof(double));
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "device_partial: cudaMalloc failed!\n");
+		goto Error;
+	}
+
+	cudaMemcpy(device_a, a.data, sizeInBytes, cudaMemcpyHostToDevice);
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "A: cudaMemcpy to device failed!\n");
+		goto Error;
+	}
+
+	l2_norm_dVector_kernel<<<gridSize, BLOCKSIZE>>>(device_a, device_partial, a.len);
+	cudaStatus = cudaGetLastError();
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "magnitude_dVector_kernel launch failed: %s\n", cudaGetErrorString(cudaStatus));
+		goto Error;
+	}
+
+	cudaStatus = cudaDeviceSynchronize();
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "cudaDeviceSynchronize returned error code %d after launching addKernel!\n", cudaStatus);
+		goto Error;
+	}
+
+	cudaMemcpy(host_partial, device_partial, gridSize * sizeof(double), cudaMemcpyDeviceToHost);
+	if (cudaStatus != cudaSuccess) {
+		fprintf(stderr, "partial: cudaMemcpy to host failed!\n");
+		goto Error;
+	}
+
+Error:
+	cudaFree(device_a);
+	cudaFree(device_partial);
+	if (cudaStatus != cudaSuccess) {
+		err = -1;
+		goto Exit;
+	}
+
+	double sum = 0;
+	for (int i = 0; i < gridSize; ++i) {
+		sum += host_partial[i];
+	}
+
+	*result = sqrt((double)sum);
+
+Exit:
+	free(host_partial);
+	return err;
 }
 
 void test_l2_norm(int n) {
-	dVector a, b, c;
+	dVector a;
 	dvector_init(a, n);
-	dvector_init(b, n);
 
 	double L2_norm = 0;
 	double euclidean_norm = 0;
 
 	for (int i = 0; i < n; ++i) {
 		a.data[i] = 1;
-		b.data[i] = 2;
 	}
 
-	l2_norm_dVectors(a, b, &L2_norm);
-	euclidean_norm_dVectors(a, b, &euclidean_norm);
+	l2_norm_dVector(a, &L2_norm);
+	euclidean_norm_dVector(a, &euclidean_norm);
 
-	//dotProduct should be 2*n
-	if (abs(L2_norm - sqrt((double)(2 * n))) > 1e-14) {
+	//L2 norm should be sqrt(n)
+	if (abs(L2_norm - sqrt((double)n)) > 1e-14) {
 		fprintf(stdout, "L2_norm=%f is not correct within error.\n", L2_norm);
 	}
 	else {
@@ -38,7 +135,6 @@ void test_l2_norm(int n) {
 	else {
 		fprintf(stdout, "Alias for euclidean_norm to l2_norm is correct.\n");
 	}
-
+	
 	dvector_free(a);
-	dvector_free(b);
 }

--- a/source/l2_norm.cuh
+++ b/source/l2_norm.cuh
@@ -5,22 +5,20 @@
 #include <math.h>
 
 #include "vector.cuh"
-#include "dot_product.cuh"
 
 /**
-Alias for l2_norm_dVectors. As such, its parameters are as follows:
-dVector a, dVector b, and double *result
+Alias for l2_norm_dVector. As such, its parameters are as follows:
+dVector a, and double *result
 */
-#define euclidean_norm_dVectors(a, b, result) l2_norm_dVectors(a, b, result);
+#define euclidean_norm_dVector(a, result) l2_norm_dVector(a, result);
 
 /**
-Computes the standard L2 norm on vectors a and b. This is calculated by taking the square root of the dot product of the two vectors.
-Depends on dot_product.cuh file.
+Computes the standard L2 norm on vector a. Norm is is SUM(a_i * a_i).
 
 *result is a pointer to where the result will be stored
 Returns: 0 on success, non-zero otherwise
 */
-int l2_norm_dVectors(dVector a, dVector b, double *result);
+int l2_norm_dVector(dVector a, double *result);
 
 void test_l2_norm(int n);
 

--- a/source/vector.cu
+++ b/source/vector.cu
@@ -1,4 +1,1 @@
 #include "vector.cuh"
-
-
-

--- a/source/vector.cuh
+++ b/source/vector.cuh
@@ -1,9 +1,6 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
-#include "cuda_runtime.h"
-#include "device_launch_parameters.h"
-
 #include <stdlib.h>
 
 /**

--- a/source/vector.cuh
+++ b/source/vector.cuh
@@ -4,8 +4,6 @@
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"
 
-#include <math.h>
-#include <stdio.h>
 #include <stdlib.h>
 
 /**

--- a/source/vector.cuh
+++ b/source/vector.cuh
@@ -1,6 +1,11 @@
 #ifndef VECTOR_H
 #define VECTOR_H
 
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+
+#include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 /**


### PR DESCRIPTION
Made the computation of the L2 norm more memory efficient for the GPU by eliminating the need for the dot product function. Previously, the using the dot product function copied the vector to the GPU twice, now we only need to perform 1 copy. Some computation still performed on the CPU.
